### PR TITLE
Remove PointSpriteHelper (lost commit from SVN)

### DIFF
--- a/SpaceShooter/Background/MotionField.cs
+++ b/SpaceShooter/Background/MotionField.cs
@@ -177,7 +177,6 @@ namespace SpaceShooter
                     starEffect.Parameters["ViewportHeight"].SetValue(GraphicsDevice.Viewport.Height);
 
                     GraphicsDevice.SetVertexBuffer(vertexBuffer);
-                    PointSpriteHelper.Enable();
 
                     // Set the alpha blend mode.
                     BlendStateHelper.BeginApply(GraphicsDevice);
@@ -199,8 +198,6 @@ namespace SpaceShooter
                         GraphicsDevice.DrawPrimitives(PrimitiveType.PointListEXT, 0, starCount);
 #endif
                     }
-
-                    PointSpriteHelper.Disable();
 
                     GraphicsDevice.SetVertexBuffer(null);
 

--- a/SpaceShooter/FrameworkCore.cs
+++ b/SpaceShooter/FrameworkCore.cs
@@ -1018,7 +1018,6 @@ namespace SpaceShooter
             sphererenderer.OnCreateDevice();
 
             pointrenderer = new PointRenderer(Game.Content.Load<Effect>("shaders/pointeffect"));
-            PointSpriteHelper.Initialize();
 
             particles.Initialize();
             boltManager.Initialize();

--- a/SpaceShooter/Helpers.cs
+++ b/SpaceShooter/Helpers.cs
@@ -27,65 +27,6 @@ namespace SpaceShooter
         public static Color TransparentBlack = new Color(0, 0, 0, 0);
     }
 
-    public static class PointSpriteHelper
-    {
-        private static bool supported = false;
-
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
-        private delegate void EnableFunc(uint cap);
-        private static EnableFunc glEnable;
-
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
-        private delegate void DisableFunc(uint cap);
-        private static DisableFunc glDisable;
-
-        private const uint GL_POINT_SPRITE = 0x8861;
-
-        public static void Initialize()
-        {
-#if SDL2
-            IntPtr enable, disable;
-            enable = SDL2.SDL.SDL_GL_GetProcAddress("glEnable");
-            disable = SDL2.SDL.SDL_GL_GetProcAddress("glDisable");
-            if (enable != IntPtr.Zero && disable != IntPtr.Zero)
-            {
-                try
-                {
-                    glEnable = (EnableFunc) Marshal.GetDelegateForFunctionPointer(
-                        enable,
-                        typeof(EnableFunc)
-                    );
-                    glDisable = (DisableFunc) Marshal.GetDelegateForFunctionPointer(
-                        disable,
-                        typeof(DisableFunc)
-                    );
-                    supported = true;
-                }
-                catch(Exception e)
-                {
-                    Console.WriteLine("Invalid GLProcAddress? " + e.ToString());
-                }
-            }
-#endif
-        }
-
-        public static void Enable()
-        {
-            if (supported)
-            {
-                glEnable(GL_POINT_SPRITE);
-            }
-        }
-
-        public static void Disable()
-        {
-            if (supported)
-            {
-                glDisable(GL_POINT_SPRITE);
-            }
-        }
-    }
-
 #if SDL2
     public static class YesNoPopup
     {

--- a/SpaceShooter/Particles/ParticleSystem.cs
+++ b/SpaceShooter/Particles/ParticleSystem.cs
@@ -423,7 +423,6 @@ namespace SpaceShooter
 
                     // Reset a couple of the more unusual renderstates that we changed,
                     // so as not to mess up any other subsequent drawing.
-                    PointSpriteHelper.Disable();
                     if (device.DepthStencilState.DepthBufferEnable)
                     {
                         device.DepthStencilState = DepthStencilState.Default;
@@ -486,8 +485,6 @@ namespace SpaceShooter
         /// </summary>
         void SetParticleRenderStates(GraphicsDevice device)
         {
-            // Enable point sprites.
-            PointSpriteHelper.Enable();
             // renderState.PointSizeMax = 256; // FIXME: Do we care? -flibit
 
             // Set the alpha blend mode.


### PR DESCRIPTION
Only just now noticed that the PointSpriteHelper removal didn't make it to the GitHub release... FNA now handles this feature automatically, in the OpenGLRenderer as well as all the fancy new renderers we've added since Flotilla's FNA update.